### PR TITLE
fix: correct spawnShot id declaration

### DIFF
--- a/packages/server/src/game/state.ts
+++ b/packages/server/src/game/state.ts
@@ -1,0 +1,15 @@
+import { Player, Shot } from "@shared/types";
+import { nanoid } from "nanoid";
+
+export const players = new Map<string, Player>();
+export const shots = new Map<string, Shot>();
+
+export function spawnShot(ownerId: string, x: number, y: number, angle: number, text: string): Shot {
+  const speed = 0.6;
+  const vx = Math.cos(angle) * speed;
+  const vy = Math.sin(angle) * speed;
+  const id = nanoid();
+  const s: Shot = { id, ownerId, x, y, vx, vy, text };
+  shots.set(id, s);
+  return s;
+}


### PR DESCRIPTION
## Summary
- fix syntax in `spawnShot` by removing extraneous token before `const`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c16ad660832c8b04d50dd1612d2a